### PR TITLE
Drastically reduce CPU usage and allocations

### DIFF
--- a/BGLibExt/SerialPortReceiveThread.cs
+++ b/BGLibExt/SerialPortReceiveThread.cs
@@ -38,29 +38,18 @@ namespace BGLibExt
             _receiveThread.Join();
         }
 
-        private void ReceivedData()
-        {
-            var bytesToRead = _serialPort.BytesToRead;
-
-            var readBytes = new byte[bytesToRead];
-
-            _serialPort.Read(readBytes, 0, bytesToRead);
-
-            foreach (var readByte in readBytes)
-            {
-                _bgLib.Parse(readByte);
-            }
-        }
-
         private void Run()
         {
+            byte[] buffer = new byte[128]; // The serial port normally only yields 1 byte at a time
             while (!_stopThread && _serialPort != null && _serialPort.IsOpen)
             {
-                if (_serialPort.BytesToRead > 0)
+                int readBytes = _serialPort.Read(buffer, 0, buffer.Length);
+                for (int i = 0; i < readBytes; i++)
                 {
-                    ReceivedData();
+                    _bgLib.Parse(buffer[i]);
                 }
-                else if (_sleepTime > 0)
+
+                if (_sleepTime > 0)
                 {
                     Thread.Sleep(_sleepTime);
                 }


### PR DESCRIPTION
`SerialPort.Read` takes a `count` parameter, which specifies the maximum
number of bytes to read from the serial port. If this is non-zero, then
the `Read` call will block until at least 1 byte has been received.

Previously, if there were no bytes available to read, then the code span
in a polling loop until a byte became available, burning CPU. It's more
efficient to call `Read` with a non-zero `count` parameter in this case,
which causes the thread to sleep until one or more bytes are available.

Change the `Run` method to follow the normal pattern of allocating a single
buffer, and then reading some number of bytes into it, and processing
just the bytes which were read. This also avoids the thousands of
allocations of single-byte arrays which were happening previously.

The `_sleepTime` field is now a bit redundent: I assume this was added
in an attempt to reduce CPU usage. I've left it in out of backwards
compatibility concerns, but it's not adding anything useful any more.